### PR TITLE
Start without emitting Source Map in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.tsx",
   "scripts": {
     "dev": "webpack serve --mode development --devtool eval-source-map",
-    "build": "webpack --mode production --devtool source-map",
+    "build": "webpack --mode production",
     "typecheck": "tsc -p . --noEmit",
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier --check src",


### PR DESCRIPTION
This is a good option to start with.

When using --devtool source-map,
You should configure your server to disallow access to the Source Map file for normal users!